### PR TITLE
BigQuery Timeout Exception

### DIFF
--- a/src/BigQueryHelper.php
+++ b/src/BigQueryHelper.php
@@ -1,8 +1,6 @@
 <?php
 namespace Packaged\BigQuery;
 
-use Fortifi\Fortifi\Applications\Developer\Exceptions\TimeoutException;
-use Fortifi\Fortifi\Infrastructure\Logging\Log;
 use Google\Cloud\BigQuery\BigQueryClient;
 use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\BigQuery\Job;
@@ -12,7 +10,7 @@ use Google\Cloud\Core\Exception\NotFoundException;
 
 class BigQueryHelper
 {
-  /** @var int Max size of the data to put in a BigQuery request when writing rows. Rememeber to allow some overhead. */
+  /** @var int Max size of the data to put in a BigQuery request when writing rows. Remember to allow some overhead. */
   const MAX_REQUEST_DATA_SIZE = 8388608; // 8MiB
 
   private $_credentials;
@@ -412,7 +410,8 @@ class BigQueryHelper
     $result = $client->runQuery($jobConfig, $queryResultsOptions);
 
     // Check whether the query has completed
-    if(($info = $result->info()) && empty($info['jobComplete']))
+    $info = $result->info();
+    if($info && empty($info['jobComplete']))
     {
       throw new BigQueryTimeoutException(
         "Timed out retrieving BigQuery data",
@@ -421,7 +420,7 @@ class BigQueryHelper
         $sql,
         isset($info["jobReference"]["projectId"]) ? $info["jobReference"]["projectId"] : '',
         isset($info["jobReference"]["jobId"]) ? $info["jobReference"]["jobId"] : '',
-        isset($info["jobReference"]["location"]) ? $info["jobReference"]["location"] : '',
+        isset($info["jobReference"]["location"]) ? $info["jobReference"]["location"] : ''
       );
     }
     return $result;

--- a/src/BigQueryHelper.php
+++ b/src/BigQueryHelper.php
@@ -337,7 +337,7 @@ class BigQueryHelper
     $result = $this->_runQuery($sql, $async, $legacySql, $extraQueryOpts);
 
     // Check whether the query has completed
-    if(!$async && $info = $result->info() && empty($info['jobComplete']))
+    if(!$async && ($info = $result->info()) && empty($info['jobComplete']))
     {
       throw new BigQueryTimeoutException(
         "Timed out retrieving BigQuery data",

--- a/src/BigQueryTimeoutException.php
+++ b/src/BigQueryTimeoutException.php
@@ -1,0 +1,48 @@
+<?php
+namespace Packaged\BigQuery;
+
+use Throwable;
+
+class BigQueryTimeoutException extends BigQueryException
+{
+  protected $_projectId;
+  protected $_jobId;
+  protected $_location;
+  protected $_query;
+
+  public function __construct(
+    $message = "", $code = 0, Throwable $previous = null, $query = "", $projectId = "", $jobId = "", $location = ""
+  )
+  {
+    parent::__construct(
+      $message,
+      $code,
+      $previous
+    );
+    $this->_query = $query;
+    $this->_projectId = $projectId;
+    $this->_jobId = $jobId;
+    $this->_location = $location;
+  }
+
+  public function getProjectId()
+  {
+    return $this->_projectId;
+  }
+
+  public function getJobId()
+  {
+    return $this->_jobId;
+  }
+
+  public function getLocation()
+  {
+    return $this->_location;
+  }
+
+  public function getQuery()
+  {
+    return $this->_query;
+  }
+
+}


### PR DESCRIPTION
If bigquery times out, it returns the partial result set. 
Instead, runQuery will now throw an exception if `jobComplete` is false on synchronous queries.